### PR TITLE
Update usage of IntelliJ APIs to match what's available with IJ 130.1365.

### DIFF
--- a/src/main/java/com/khmelyuk/multirun/MultirunRunConfiguration.java
+++ b/src/main/java/com/khmelyuk/multirun/MultirunRunConfiguration.java
@@ -9,7 +9,6 @@ import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
-import com.intellij.openapi.util.JDOMExternalizable;
 import com.intellij.openapi.util.WriteExternalException;
 import com.khmelyuk.multirun.ui.MultirunRunConfigurationEditor;
 import org.jdom.Element;
@@ -160,13 +159,13 @@ public class MultirunRunConfiguration extends RunConfigurationBase {
 
     @Nullable
     @Override
-    public JDOMExternalizable createRunnerSettings(ConfigurationInfoProvider configurationInfoProvider) {
+    public ConfigurationPerRunnerSettings createRunnerSettings( ConfigurationInfoProvider configurationInfoProvider ) {
         return null;
     }
 
     @Nullable
     @Override
-    public SettingsEditor<JDOMExternalizable> getRunnerSettingsEditor(ProgramRunner programRunner) {
+    public SettingsEditor<ConfigurationPerRunnerSettings> getRunnerSettingsEditor( ProgramRunner programRunner ) {
         return null;
     }
 

--- a/src/main/java/com/khmelyuk/multirun/MultirunRunnerState.java
+++ b/src/main/java/com/khmelyuk/multirun/MultirunRunnerState.java
@@ -88,11 +88,12 @@ public class MultirunRunnerState implements RunnableState {
 
             runTriggers(executor, configuration);
             RunContentDescriptor runContentDescriptor = getRunContentDescriptor(runConfiguration, project);
-            ExecutionEnvironment executionEnvironment = new ExecutionEnvironment(
-                    runner, DefaultExecutionTarget.INSTANCE,
-                    configuration, runContentDescriptor, project);
+            ExecutionEnvironment executionEnvironment = new ExecutionEnvironment( configuration.getConfiguration(),
+	                  executor, DefaultExecutionTarget.INSTANCE, project, configuration.getRunnerSettings( runner ),
+	                  configuration.getConfigurationSettings( runner ), runContentDescriptor, configuration,
+	                  runner.getRunnerId() );
 
-            runner.execute(executor, executionEnvironment, new ProgramRunner.Callback() {
+            runner.execute(executionEnvironment, new ProgramRunner.Callback() {
                 @SuppressWarnings("ConstantConditions")
                 @Override
                 public void processStarted(final RunContentDescriptor descriptor) {
@@ -263,13 +264,4 @@ public class MultirunRunnerState implements RunnableState {
         return !runContentDescriptors.isEmpty() ? runContentDescriptors.get(0) : null;
     }
 
-    @Override
-    public RunnerSettings getRunnerSettings() {
-        return null;
-    }
-
-    @Override
-    public ConfigurationPerRunnerSettings getConfigurationSettings() {
-        return null;
-    }
 }


### PR DESCRIPTION
I did not try to update the plugin version, as I don't know how you would want to handle this.

I did open the project which originally exposed the issue, and verified that I could now use the Multirun configurations I had previously configured.
