### PR TITLE
adding support for JRebel run configurations

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.khmelyuk.multirun</id>
     <name>Multirun</name>
-    <version>0.9</version>
+    <version>0.9.1</version>
     <vendor url="http://www.khmelyuk.com">Ruslan Khmelyuk</vendor>
 
     <description>
@@ -32,6 +32,10 @@
 
     <change-notes>
         <![CDATA[
+        <p><strong>0.9.1</strong>:</p>
+        <ul>
+            <li>Adding JRebel support</li>
+        </ul>
         <p><strong>0.9</strong>:</p>
         <ul>
             <li>Fixed API issues with using Multirun from IntellijIDEA 14 (thanks derkork!)</li>

--- a/src/main/java/com/khmelyuk/multirun/MultirunRunner.java
+++ b/src/main/java/com/khmelyuk/multirun/MultirunRunner.java
@@ -4,6 +4,7 @@ import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.DefaultProgramRunner;
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -12,6 +13,9 @@ import org.jetbrains.annotations.NotNull;
  * @author Ruslan Khmelyuk
  */
 public class MultirunRunner extends DefaultProgramRunner {
+
+    public static final String JREBEL_EXECUTOR_ID = "JRebel Executor";
+    public static final String JREBEL_DEBUG_ID = "JRebel Debug";
 
     @NotNull
     @Override
@@ -23,6 +27,8 @@ public class MultirunRunner extends DefaultProgramRunner {
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
         return runProfile instanceof MultirunRunConfiguration &&
                 (DefaultRunExecutor.EXECUTOR_ID.equals(executorId)
-                        || DefaultDebugExecutor.EXECUTOR_ID.equals(executorId));
+                        || DefaultDebugExecutor.EXECUTOR_ID.equals(executorId)
+                        || JREBEL_EXECUTOR_ID.equalsIgnoreCase(executorId)
+                        || JREBEL_DEBUG_ID.equalsIgnoreCase(executorId));
     }
 }


### PR DESCRIPTION
Hey

just adds "JRebel Executor" and "JRebel Debug" to the canRun() check so that multirun can start JRebel configurations.

cheers

Oliver
