### PR TITLE
Idea 2017.2 support

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.khmelyuk.multirun</id>
     <name>Multirun</name>
-    <version>1.6</version>
+    <version>1.7</version>
     <vendor url="http://www.khmelyuk.com">Ruslan Khmelyuk</vendor>
 
     <description>
@@ -32,6 +32,10 @@
 
     <change-notes>
         <![CDATA[
+        <p><strong>1.7</strong>:</p>
+        <ul>
+            <li>Support for IntellijIDEA 2017.2</li>
+        </ul>
         <p><strong>1.6</strong>:</p>
         <ul>
             <li>Support for IntellijIDEA 2017.1</li>
@@ -131,7 +135,7 @@
     </change-notes>
 
     <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="171.0000" until-build="171.*"/>
+    <idea-version since-build="172.0000" until-build="172.*"/>
 
     <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
Support for IntelliJ 2017.2 EAP that came out yesterday.

Tested locally and works perfectly.
Set new version to 1.7.